### PR TITLE
Fixed epsilon decay in dqn example

### DIFF
--- a/lightning_examples/reinforce-learning-DQN/.meta.yml
+++ b/lightning_examples/reinforce-learning-DQN/.meta.yml
@@ -13,6 +13,10 @@ description: |
   2. Handle unsupervised learning by using an IterableDataset where the dataset itself is constantly updated during training
   3. Each training step carries has the agent taking an action in the environment and storing the experience in the IterableDataset
 requirements:
+  - torch>=1.6, <1.9
+  - torchvision<=0.10
+  - torchaudio<=0.10
+  - torchtext<=0.10
   - gym
 accelerator:
   - CPU

--- a/lightning_examples/reinforce-learning-DQN/.meta.yml
+++ b/lightning_examples/reinforce-learning-DQN/.meta.yml
@@ -1,7 +1,7 @@
 title: How to train a Deep Q Network
 author: PL team
 created: 2021-01-31
-updated: 2021-06-17
+updated: 2021-12-03
 license: CC BY-SA
 build: 1
 tags:

--- a/lightning_examples/reinforce-learning-DQN/.meta.yml
+++ b/lightning_examples/reinforce-learning-DQN/.meta.yml
@@ -3,7 +3,7 @@ author: PL team
 created: 2021-01-31
 updated: 2021-12-03
 license: CC BY-SA
-build: 2
+build: 1
 tags:
   - RL
 description: |
@@ -13,7 +13,6 @@ description: |
   2. Handle unsupervised learning by using an IterableDataset where the dataset itself is constantly updated during training
   3. Each training step carries has the agent taking an action in the environment and storing the experience in the IterableDataset
 requirements:
-  - torch>=1.6, <1.9
   - torchvision<=0.10
   - torchaudio<=0.10
   - torchtext<=0.10

--- a/lightning_examples/reinforce-learning-DQN/dqn.py
+++ b/lightning_examples/reinforce-learning-DQN/dqn.py
@@ -287,8 +287,7 @@ class DQNLightning(LightningModule):
     def get_epsilon(self, start: int, end: int, frames: int) -> float:
         if self.global_step > frames:
             return end
-        else:
-            return start - (self.global_step / frames) * (start - end)
+        return start - (self.global_step / frames) * (start - end)
 
     def training_step(self, batch: Tuple[Tensor, Tensor], nb_batch) -> OrderedDict:
         """Carries out a single step through the environment to update the replay buffer. Then calculates loss

--- a/lightning_examples/reinforce-learning-DQN/dqn.py
+++ b/lightning_examples/reinforce-learning-DQN/dqn.py
@@ -367,7 +367,7 @@ model = DQNLightning()
 
 trainer = Trainer(
     gpus=AVAIL_GPUS,
-    max_epochs=400,
+    max_epochs=200,
     val_check_interval=100,
 )
 

--- a/lightning_examples/reinforce-learning-DQN/dqn.py
+++ b/lightning_examples/reinforce-learning-DQN/dqn.py
@@ -1,7 +1,7 @@
 # %%
 import os
 from collections import OrderedDict, deque, namedtuple
-from typing import List, Tuple, Iterator
+from typing import Iterator, List, Tuple
 
 import gym
 import numpy as np
@@ -29,7 +29,11 @@ class DQN(nn.Module):
             hidden_size: size of hidden layers
         """
         super().__init__()
-        self.net = nn.Sequential(nn.Linear(obs_size, hidden_size), nn.ReLU(), nn.Linear(hidden_size, n_actions),)
+        self.net = nn.Sequential(
+            nn.Linear(obs_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, n_actions),
+        )
 
     def forward(self, x):
         return self.net(x.float())
@@ -41,7 +45,10 @@ class DQN(nn.Module):
 # %%
 
 # Named tuple for storing experience steps gathered in training
-Experience = namedtuple("Experience", field_names=["state", "action", "reward", "done", "new_state"],)
+Experience = namedtuple(
+    "Experience",
+    field_names=["state", "action", "reward", "done", "new_state"],
+)
 
 
 # %%
@@ -147,7 +154,12 @@ class Agent:
         return action
 
     @torch.no_grad()
-    def play_step(self, net: nn.Module, epsilon: float = 0.0, device: str = "cpu",) -> Tuple[float, bool]:
+    def play_step(
+        self,
+        net: nn.Module,
+        epsilon: float = 0.0,
+        device: str = "cpu",
+    ) -> Tuple[float, bool]:
         """Carries out a single interaction step between the agent and the environment.
 
         Args:
@@ -332,7 +344,10 @@ class DQNLightning(LightningModule):
     def __dataloader(self) -> DataLoader:
         """Initialize the Replay Buffer dataset used for retrieving experiences."""
         dataset = RLDataset(self.buffer, self.hparams.episode_length)
-        dataloader = DataLoader(dataset=dataset, batch_size=self.hparams.batch_size,)
+        dataloader = DataLoader(
+            dataset=dataset,
+            batch_size=self.hparams.batch_size,
+        )
         return dataloader
 
     def train_dataloader(self) -> DataLoader:
@@ -351,7 +366,11 @@ class DQNLightning(LightningModule):
 
 model = DQNLightning()
 
-trainer = Trainer(gpus=AVAIL_GPUS, max_epochs=400, val_check_interval=100,)
+trainer = Trainer(
+    gpus=AVAIL_GPUS,
+    max_epochs=400,
+    val_check_interval=100,
+)
 
 trainer.fit(model)
 


### PR DESCRIPTION
# Before submitting

- I raised this issue on github, issue https://github.com/PyTorchLightning/pytorch-lightning/discussions/10883. The user @awaelchli said to fork the repo, clone it to my local machine, make my changes, push to my repo, and then submit a pull request.
- This is my first attempt to contribute to an open-source project, so please let me know if I've done anything incorrectly.
- I could not find where the unit tests are kept for the example colab notebooks. I would be happy to upload my unit tests for the get_epsilon method, but I don't know where to put them in the codebase.

## What does this PR do?

This fixes issue  https://github.com/PyTorchLightning/pytorch-lightning/discussions/10883, where there was an incorrect version of epsilon decay for the epsilon-random policy of a DQN. The original code has a single `train_step` with `self.hparams.eps_start` and then immediately switches to `self.hparams.eps_end`. The intended behavior is to linearly decrease epsilon from `self.haparms.eps_start` to `self.hparams.eps_end` over the first `self.hparams.eps_last_frame` steps. I wrote a small function `get_epsilon` which fixes this logic and returns the correct epsilon.

I have also made a few minor changes on other lines, because the code would not run on my local machine without these changes. Specifically, the type hint for the `__iter__` method of the `RLDataset` class was a Tuple, and should be an Iterator[Tuple], because it returns a generator of tuples representing (state, action, reward, done, new_state). Additionally, on line 264 (formerly 276), I got an error that the index for the `gather()` function must be of type `int64`, so I cast the `actions` tensor to type long. Finally, I added logging of `self.episode_reward` and `epsilon`, so that I could see that a) it still learned successfully, and b) my intended changes to epsilon were working as intended.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Sure did!
