### PR TITLE
Adjust papermill references for the release of 2.3.4

### DIFF
--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -320,7 +320,7 @@ class AssistantCLI:
         else:
             cmd.append(f"# available: {AssistantCLI.DEVICE_ACCELERATOR}\n")
             if AssistantCLI._valid_accelerator(folder):
-                cmd.append(f"python -m papermill.cli {ipynb_file} {pub_ipynb} --kernel python")
+                cmd.append(f"python -m papermill {ipynb_file} {pub_ipynb} --kernel python")
             else:
                 warn("Invalid notebook's accelerator for this device. So no outputs will be generated.", RuntimeWarning)
                 cmd.append(f"cp {ipynb_file} {pub_ipynb}")

--- a/.azure/ipynb-publish.yml
+++ b/.azure/ipynb-publish.yml
@@ -64,7 +64,7 @@ jobs:
     - bash: |
         set -e
         python -c "import torch ; mgpu = torch.cuda.device_count() ; assert mgpu > 0, f'GPU: {mgpu}'"
-        python -m papermill.cli --version
+        python -m papermill --version
       displayName: 'Sanity check'
 
     - bash: |

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -2,7 +2,7 @@ virtualenv
 jupytext  # converting
 pytest>=6.0
 nbval  # testing
-papermill  # render
+papermill>=2.3.4  # render
 black
 flake8
 isort


### PR DESCRIPTION
# Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you make sure to update the docs?
- [X] Did you write any new necessary tests?

## What does this PR do?

Fixes #136 .

With the latest papermill release (2.3.4, updated 2022.01.22), a [PR has been included](https://github.com/nteract/papermill/pull/608) that necessitates a change in our papermill.cli references to papermill

As part of the `make ipynb` process, you'll notice `python -m papermill.cli {ipynb_file} {pub_ipynb} --kernel python` fails. Updating it to `python -m papermill {ipynb_file} {pub_ipynb} --kernel python` succeeds.

In this PR I'm submitting to fix this, I'm also updating requirements to ensure papermill >=2.3.4 as previously, `papermill.cli` was necessary.

The [improvement to papermill](https://github.com/nteract/papermill/pull/608) was originally made by @Borda and now is finally available. Thanks!

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
