### PR TITLE
Bugfix text-transformers.py

### DIFF
--- a/lightning_examples/text-transformers/text-transformers.py
+++ b/lightning_examples/text-transformers/text-transformers.py
@@ -99,7 +99,7 @@ class GLUEDataModule(LightningDataModule):
         AutoTokenizer.from_pretrained(self.model_name_or_path, use_fast=True)
 
     def train_dataloader(self):
-        return DataLoader(self.dataset["train"], batch_size=self.train_batch_size)
+        return DataLoader(self.dataset["train"], batch_size=self.train_batch_size, shuffle=True)
 
     def val_dataloader(self):
         if len(self.eval_splits) == 1:
@@ -183,7 +183,7 @@ class GLUETransformer(LightningModule):
         outputs = self(**batch)
         val_loss, logits = outputs[:2]
 
-        if self.hparams.num_labels >= 1:
+        if self.hparams.num_labels > 1:
             preds = torch.argmax(logits, axis=1)
         elif self.hparams.num_labels == 1:
             preds = logits.squeeze()


### PR DESCRIPTION
This proposal fixes two bugs in the Huggingface transformers pytorch lightning example:
1) The example did not work on the stsb task for GLUE, as you have the wrong if condition (it is always true). Changing `>= 1` to `> 1` fixes it.
2) The train data loader did not shuffle the dataset, which leads to quite a large performance drop for some datasets on glue. Adding shuffle=True to the train dataloader fixes it and gives comparable results to e.g. the HuggingFace trainer class.


Also note that this needs to be fixed in the docs:
https://pytorch-lightning.readthedocs.io/en/stable/notebooks/lightning_examples/text-transformers.html

When you click on that page on "Edit on Github", it leads to a 404 page.