### PR TITLE
fix stale ffmpeg ref

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update --fix-missing
           sudo apt install -y ffmpeg
           pip --version
           pip install --requirement requirements.txt --find-links https://download.pytorch.org/whl/cpu/torch_stable.html


### PR DESCRIPTION
## Before submitting

- [X] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [X] Did you make sure to **update the docs**?
- [X] Did you write any new **necessary tests**?

## What does this PR do?

Fixes #177 
CI testing / nbval workflow was failing in the dependency installation step (due to stale ffmpeg ref).

Note that the build-docs check will not pass until https://github.com/PyTorchLightning/lightning-tutorials/pull/176 is merged.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
